### PR TITLE
SIArrow operators with SemiIso on the right were made to be infixl

### DIFF
--- a/Control/SIArrow.hs
+++ b/Control/SIArrow.hs
@@ -45,7 +45,7 @@ import Data.Semigroupoid.Dual
 import Prelude hiding (id, (.))
 
 infixr 1 ^>>, ^<<, #>>, #<<
-infixr 1 >>^, <<^, >>#, <<#
+infixl 1 >>^, <<^, >>#, <<#
 infixl 4 /$/
 infixl 5 /*/, */, /*
 infixl 3 /?/


### PR DESCRIPTION
Correct me it I'm wrong, but it seems that current (right) associativity of operators like `>>^` unables to use chained versions at all: `siarrow >>^ semiiso1 >>^ semiiso2` fails since it tries to have `siarrow >>^ (semiiso1 >>^ semiiso2)` but semiisos do not have `>>^` operator.

That's why I suggest to make them left-associative.